### PR TITLE
#125 Add support for deserializing on to an IndexedSeq

### DIFF
--- a/src/main/java/io/vavr/jackson/datatype/deserialize/SeqDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/SeqDeserializer.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import io.vavr.collection.Array;
+import io.vavr.collection.IndexedSeq;
 import io.vavr.collection.Queue;
 import io.vavr.collection.Seq;
 import io.vavr.collection.Stream;
@@ -44,6 +45,9 @@ class SeqDeserializer extends ArrayDeserializer<Seq<?>> {
     @Override
     Seq<?> create(List<Object> result, DeserializationContext ctxt) throws JsonMappingException {
         if (Array.class.isAssignableFrom(javaType.getRawClass())) {
+            return Array.ofAll(result);
+        }
+        if (IndexedSeq.class.isAssignableFrom(javaType.getRawClass())) {
             return Array.ofAll(result);
         }
         if (Queue.class.isAssignableFrom(javaType.getRawClass())) {

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/SeqDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/SeqDeserializer.java
@@ -47,9 +47,6 @@ class SeqDeserializer extends ArrayDeserializer<Seq<?>> {
         if (Array.class.isAssignableFrom(javaType.getRawClass())) {
             return Array.ofAll(result);
         }
-        if (IndexedSeq.class.isAssignableFrom(javaType.getRawClass())) {
-            return Array.ofAll(result);
-        }
         if (Queue.class.isAssignableFrom(javaType.getRawClass())) {
             return Queue.ofAll(result);
         }
@@ -58,6 +55,9 @@ class SeqDeserializer extends ArrayDeserializer<Seq<?>> {
         }
         if (Vector.class.isAssignableFrom(javaType.getRawClass())) {
             return Vector.ofAll(result);
+        }
+        if (IndexedSeq.class.isAssignableFrom(javaType.getRawClass())) {
+            return Array.ofAll(result);
         }
         // default deserialization [...] -> Seq
         return io.vavr.collection.List.ofAll(result);

--- a/src/test/java/io/vavr/jackson/datatype/seq/IndexedSeqTest.java
+++ b/src/test/java/io/vavr/jackson/datatype/seq/IndexedSeqTest.java
@@ -1,0 +1,26 @@
+package io.vavr.jackson.datatype.seq;
+
+import java.util.Arrays;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.vavr.collection.Array;
+import io.vavr.collection.IndexedSeq;
+import io.vavr.collection.Seq;
+import io.vavr.control.Option;
+
+public class IndexedSeqTest extends SeqTest {
+    @Override
+    protected Class<?> clz() {
+        return Array.class;
+    }
+
+    @Override
+    protected TypeReference<IndexedSeq<Option<String>>> typeReferenceWithOption() {
+        return new TypeReference<IndexedSeq<Option<String>>>() {};
+    }
+
+    @Override
+    protected Seq<?> of(Object... objects) {
+        return Array.ofAll(Arrays.asList(objects));
+    }
+}


### PR DESCRIPTION
Changes `SeqDeserializer` to support deserializing on to properties of type `IndexedSeq`.