### PR TITLE
Fix build failure

### DIFF
--- a/src/test/java/io/vavr/jackson/datatype/seq/StreamTest.java
+++ b/src/test/java/io/vavr/jackson/datatype/seq/StreamTest.java
@@ -21,7 +21,7 @@ public class StreamTest extends SeqTest {
 
     @Override
     protected String implClzName() {
-        return "io.vavr.collection.StreamModule$ConsImpl";
+        return "io.vavr.collection.Stream$ConsImpl";
     }
 
     @Override


### PR DESCRIPTION
Since https://github.com/vavr-io/vavr/commit/cce4332047ff8059d359ca92174a0f025642b96c, interface `StreamModule` had been removed from class `Stream`class. All nested classes including `ConsImpl`, have been merged into `Stream`:

```diff
@@ -1921,11 +1930,8 @@ public interface Stream<T> extends LinearSeq<T> {
             return builder.append(")").toString();
         }
     }
-}
-
-interface StreamModule {

-    final class ConsImpl<T> extends Cons<T> implements Serializable {
+    private static final class ConsImpl<T> extends Cons<T> implements Serializable {

         private static final long serialVersionUID = 1L;
```