### PR TITLE
Fix deserialization issue on Map<String, String> when value is null

### DIFF
--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MapDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MapDeserializer.java
@@ -43,8 +43,15 @@ class MapDeserializer extends MaplikeDeserializer<Map<?, ?>> {
         while (p.nextToken() != JsonToken.END_OBJECT) {
             String name = p.getCurrentName();
             Object key = keyDeserializer.deserializeKey(name, ctxt);
-            p.nextToken();
-            result.add(Tuple.of(key, valueDeserializer.deserialize(p, ctxt)));
+            JsonToken t = p.nextToken();
+            // Note: must handle null explicitly here; value deserializers won't
+            Object value;
+            if (t == JsonToken.VALUE_NULL) {
+                value = valueDeserializer.getNullValue(ctxt);
+            } else {
+                value = valueDeserializer.deserialize(p, ctxt);
+            }
+            result.add(Tuple.of(key, value));
         }
         if (SortedMap.class.isAssignableFrom(handledType())) {
             return TreeMap.ofEntries(keyComparator, result);

--- a/src/test/java/io/vavr/jackson/datatype/map/MapTest.java
+++ b/src/test/java/io/vavr/jackson/datatype/map/MapTest.java
@@ -61,6 +61,17 @@ public abstract class MapTest extends BaseTest {
         Assert.assertEquals(src, restored);
     }
 
+    // Issue 138: Cannot deserialize to Map<String, String>
+    // https://github.com/vavr-io/vavr-jackson/issues/138
+    @Test
+    public void testDeserializeNullValue() throws IOException {
+        Map<String, String> stringStringMap = mapper().readValue("{\"1\":null}", new TypeReference<Map<String, String>>() {});
+        Map<String, Object> stringObjectMap = mapper().readValue("{\"1\":null}", new TypeReference<Map<String, Object>>() {});
+
+        Assert.assertEquals(emptyMap().put("1", null), stringStringMap);
+        Assert.assertEquals(emptyMap().put("1", null), stringObjectMap);
+    }
+
     @Test(expected = JsonParseException.class)
     public void test4() throws IOException {
         mapper().readValue("{1: 1}", clz());


### PR DESCRIPTION
Fix https://github.com/vavr-io/vavr-jackson/issues/138: Cannot deserialize to Map<String, String>.

Align with the behavior of Jackson Databind's standard [`MapDeserializer`](https://github.com/FasterXML/jackson-databind/blob/jackson-databind-2.7.2/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java) on value filling, where null value is [handled explicitly](https://github.com/FasterXML/jackson-databind/blob/jackson-databind-2.7.2/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java#L490-L498) via `getNullValue()`. More precisely, their `MapDeserializer` uses [two different logic](https://github.com/FasterXML/jackson-databind/blob/jackson-databind-2.7.2/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java#L340-L344): `_readAndBindStringMap` and `_readAndBind`, respectively for string map and other map. Both methods treat null value explicitly as:

```java
// Note: must handle null explicitly here; value deserializers won't
Object value;
if (t == JsonToken.VALUE_NULL) {
    value = valueDes.getNullValue(ctxt);
} else if (typeDeser == null) {
    value = valueDes.deserialize(p, ctxt);
} else {
    value = valueDes.deserializeWithType(p, ctxt, typeDeser);
}
```