### PR TITLE
Check deserialization on null value

### DIFF
--- a/src/test/java/io/vavr/jackson/datatype/bean/BeanTest.java
+++ b/src/test/java/io/vavr/jackson/datatype/bean/BeanTest.java
@@ -153,4 +153,15 @@ public class BeanTest extends BaseTest {
         Assert.assertEquals(restored, src);
     }
 
+    @Test
+    public void testDeserializeScalarNull() throws IOException {
+        // language=JSON
+        String json = "{\"scalar\":null,\"value\":[]}";
+
+        BeanObject actual = mapper().readValue(json, BeanObject.class);
+
+        BeanObject expected = new BeanObject();
+        expected.value = List.empty();
+        Assert.assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/io/vavr/jackson/datatype/multimap/MultimapTest.java
+++ b/src/test/java/io/vavr/jackson/datatype/multimap/MultimapTest.java
@@ -1,8 +1,12 @@
 package io.vavr.jackson.datatype.multimap;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vavr.Tuple;
+import io.vavr.collection.HashMap;
+import io.vavr.collection.Multimap;
+import io.vavr.control.Option;
 import io.vavr.jackson.datatype.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -11,11 +15,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import io.vavr.Tuple;
-import io.vavr.collection.HashMap;
-import io.vavr.collection.Multimap;
-import io.vavr.control.Option;
 
 import static java.util.Arrays.asList;
 
@@ -49,6 +48,11 @@ public abstract class MultimapTest extends BaseTest {
         Multimap<Object, Object> src = emptyMap().put("1", 2).put("2", 3).put("2", 4);
         Multimap<?, ?> restored = (Multimap<?, ?>) mapper.readValue(mapper.writeValueAsString(src), clz());
         checkSerialization(restored);
+    }
+
+    @Test(expected = JsonMappingException.class)
+    public void testDeserializeValueNull() throws IOException {
+        mapper().readValue("{\"k\":null}", clz());
     }
 
     @Test


### PR DESCRIPTION
This pull request handles the remaining part of "#138: Cannot deserialize to Map<String, String>", left by pull request https://github.com/vavr-io/vavr-jackson/pull/139. Other serializers might be affected by the same problem (see https://github.com/vavr-io/vavr-jackson/pull/139#pullrequestreview-294619321). The origin problem was the incorrect deserialization on null value:

```json
{ "k": null }
```

and #139 only addressed the MapDeserializer. From what I can see, the two remaining deserializations potentially affected are "Bean Deserialization" and "Multimap Deserialization". For Bean Deserialization, a scalar value can be null. Test case `testDeserializeScalarNull` is added 
to ensure the JSON can be deserialized correctly; For Multimap Deserialization, a value must be a container (Set, SortedSet, Seq) but never be null. Test case `testDeserializeValueNull` is added to ensure an exception thrown when null found.

Other deserializers are Value Deserializers. They are not impacted.