### PR TITLE
OptionSerializer and OptionDeserializer are contextual

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     testCompile "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:${fasterxmlVersion}"
     testCompile "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${fasterxmlVersion}"
     testCompile "com.fasterxml.jackson.datatype:jackson-datatype-joda:${fasterxmlVersion}"
+    testCompile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${fasterxmlVersion}"
+    testCompile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${fasterxmlVersion}"
     testCompile "com.fasterxml.jackson.module:jackson-module-scala_2.11:${fasterxmlVersion}"
 }
 

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/OptionDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/OptionDeserializer.java
@@ -21,33 +21,48 @@ package io.vavr.jackson.datatype.deserialize;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import io.vavr.control.Option;
 
 import java.io.IOException;
 
-class OptionDeserializer extends ValueDeserializer<Option<?>> {
+class OptionDeserializer extends ValueDeserializer<Option<?>> implements ContextualDeserializer {
 
     private static final long serialVersionUID = 1L;
 
-    private final JavaType javaType;
+    private final JavaType fullType;
+    private final JavaType valueType;
     private final boolean plainMode;
+    private final TypeDeserializer valueTypeDeserializer;
+    private final JsonDeserializer<?> valueDeserializer;
     private JsonDeserializer<?> stringDeserializer;
 
-    OptionDeserializer(JavaType valueType, boolean plainMode) {
-        super(valueType, 1);
-        this.javaType = valueType;
+    OptionDeserializer(JavaType fullType, JavaType valueType, TypeDeserializer typeDeser, JsonDeserializer<?> valueDeser, boolean plainMode) {
+        super(fullType, 1);
+        this.fullType = fullType;
+        this.valueType = valueType;
+        this.valueTypeDeserializer = typeDeser;
+        this.valueDeserializer = valueDeser;
         this.plainMode = plainMode;
+    }
+
+    private OptionDeserializer(OptionDeserializer origin, TypeDeserializer typeDeser, JsonDeserializer<?> valueDeser) {
+        this(origin.fullType, origin.valueType, typeDeser, valueDeser, origin.plainMode);
+        this.stringDeserializer = origin.stringDeserializer;
     }
 
     @Override
     public Option<?> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         if (plainMode) {
-            Object obj = deserializer(0).deserialize(p, ctxt);
-            return Option.of(obj);
+            if (valueTypeDeserializer == null) {
+                Object obj = valueDeserializer.deserialize(p, ctxt);
+                return Option.of(obj);
+            } else {
+                Object obj = valueDeserializer.deserializeWithType(p, ctxt, valueTypeDeserializer);
+                return Option.of(obj);
+            }
         }
         boolean defined = false;
         Object value = null;
@@ -63,22 +78,26 @@ class OptionDeserializer extends ValueDeserializer<Option<?>> {
                     } else if ("undefined".equals(def)) {
                         defined = false;
                     } else {
-                        throw mappingException(ctxt, javaType.getRawClass(), currentToken);
+                        throw mappingException(ctxt, fullType.getRawClass(), currentToken);
                     }
                     break;
                 case 2:
-                    value = deserializer(0).deserialize(p, ctxt);
+                    if (valueTypeDeserializer == null) {
+                        value = valueDeserializer.deserialize(p, ctxt);
+                    } else {
+                        value = valueDeserializer.deserializeWithType(p, ctxt, valueTypeDeserializer);
+                    }
                     break;
             }
         }
         if (defined) {
             if (cnt != 2) {
-                throw mappingException(ctxt, javaType.getRawClass(), null);
+                throw mappingException(ctxt, fullType.getRawClass(), null);
             }
             return Option.some(value);
         } else {
             if (cnt != 1) {
-                throw mappingException(ctxt, javaType.getRawClass(), null);
+                throw mappingException(ctxt, fullType.getRawClass(), null);
             }
             return Option.none();
         }
@@ -93,5 +112,33 @@ class OptionDeserializer extends ValueDeserializer<Option<?>> {
     @Override
     public Option<?> getNullValue(DeserializationContext ctxt) throws JsonMappingException {
         return Option.none();
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) throws JsonMappingException {
+        JsonDeserializer<?> deser = valueDeserializer;
+        TypeDeserializer typeDeser = valueTypeDeserializer;
+        JavaType refType = valueType;
+
+        if (deser == null) {
+            deser = ctxt.findContextualValueDeserializer(refType, property);
+        } else { // otherwise directly assigned, probably not contextual yet:
+            deser = ctxt.handleSecondaryContextualization(deser, property, refType);
+        }
+        if (typeDeser != null) {
+            typeDeser = typeDeser.forProperty(property);
+        }
+        return withResolved(refType, typeDeser, deser);
+    }
+
+    /**
+     * Overridable fluent factory method used for creating contextual
+     * instances.
+     */
+    private OptionDeserializer withResolved(JavaType refType, TypeDeserializer typeDeser, JsonDeserializer<?> valueDeser) {
+        if (refType == valueType && valueDeser == valueDeserializer && typeDeser == valueTypeDeserializer) {
+            return this;
+        }
+        return new OptionDeserializer(this, typeDeser, valueDeser);
     }
 }

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/VavrDeserializers.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/VavrDeserializers.java
@@ -146,7 +146,7 @@ public class VavrDeserializers extends Deserializers.Base {
             return new LazyDeserializer(type);
         }
         if (raw == Option.class) {
-            return new OptionDeserializer(type, settings.useOptionInPlainFormat());
+            return new OptionDeserializer(type, type.getContentType(), contentTypeDeserializer, contentDeserializer, settings.useOptionInPlainFormat());
         }
         return super.findReferenceDeserializer(type, config, beanDesc, contentTypeDeserializer, contentDeserializer);
     }

--- a/src/main/java/io/vavr/jackson/datatype/serialize/OptionSerializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/serialize/OptionSerializer.java
@@ -20,29 +20,48 @@
 package io.vavr.jackson.datatype.serialize;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.ser.ContextualSerializer;
 import io.vavr.control.Option;
 
 import java.io.IOException;
 
-class OptionSerializer extends HListSerializer<Option<?>> {
+class OptionSerializer extends HListSerializer<Option<?>> implements ContextualSerializer {
 
     private static final long serialVersionUID = 1L;
 
     private final boolean plainMode;
 
-    OptionSerializer(JavaType contentType, boolean plainMode) {
-        super(contentType);
-        this.plainMode = plainMode;
-    }
+    private final TypeSerializer valueTypeSerializer;
 
+    private final JsonSerializer<Object> valueSerializer;
+
+    private final JavaType fullType;
+
+    private final JavaType valueType;
+
+    @SuppressWarnings("unchecked")
+    OptionSerializer(JavaType fullType, JavaType valueType, TypeSerializer valueTypeSerializer, JsonSerializer<?> valueSerializer, boolean plainMode) {
+        super(fullType);
+        this.fullType = fullType;
+        this.valueType = valueType;
+        this.plainMode = plainMode;
+        this.valueTypeSerializer = valueTypeSerializer;
+        this.valueSerializer = (JsonSerializer<Object>)  valueSerializer;
+    }
 
     @Override
     public void serialize(Option<?> value, JsonGenerator gen, SerializerProvider provider) throws IOException {
         if (plainMode) {
             if (value.isDefined()) {
-                write(value.get(), 0, gen, provider);
+                if (valueSerializer != null) {
+                    valueSerializer.serialize(value.get(), gen, provider);
+                } else {
+                    write(value.get(), 0, gen, provider);
+                }
             } else {
                 gen.writeNull();
             }
@@ -62,4 +81,61 @@ class OptionSerializer extends HListSerializer<Option<?>> {
     public boolean isEmpty(SerializerProvider provider, Option<?> value) {
         return value.isEmpty();
     }
+
+    @Override
+    public JsonSerializer<?> createContextual(SerializerProvider provider, BeanProperty property) throws JsonMappingException {
+        TypeSerializer vts = valueTypeSerializer;
+        if (vts != null) {
+            vts = vts.forProperty(property);
+        }
+        JsonSerializer<?> ser = valueSerializer;
+        if (ser == null) {
+            // A few conditions needed to be able to fetch serializer here:
+            if (useStatic(provider, property, valueType)) {
+                ser = provider.findTypedValueSerializer(valueType, true, property);
+            }
+        } else {
+            ser = provider.handlePrimaryContextualization(ser, property);
+        }
+        return withResolved(fullType, vts, ser);
+    }
+
+    private boolean useStatic(SerializerProvider provider, BeanProperty property, JavaType referredType) {
+        // First: no serializer for `Object.class`, must be dynamic
+        if (referredType.isJavaLangObject()) {
+            return false;
+        }
+        // but if type is final, might as well fetch
+        if (referredType.isFinal()) { // or should we allow annotation override? (only if requested...)
+            return true;
+        }
+        // also: if indicated by typing, should be considered static
+        if (referredType.useStaticType()) {
+            return true;
+        }
+        // if neither, maybe explicit annotation?
+        AnnotationIntrospector intr = provider.getAnnotationIntrospector();
+        if ((intr != null) && (property != null)) {
+            Annotated ann = property.getMember();
+            if (ann != null) {
+                JsonSerialize.Typing t = intr.findSerializationTyping(property.getMember());
+                if (t == JsonSerialize.Typing.STATIC) {
+                    return true;
+                }
+                if (t == JsonSerialize.Typing.DYNAMIC) {
+                    return false;
+                }
+            }
+        }
+        // and finally, may be forced by global static typing (unlikely...)
+        return provider.isEnabled(MapperFeature.USE_STATIC_TYPING);
+    }
+
+    private OptionSerializer withResolved(JavaType refType, TypeSerializer typeSer, JsonSerializer<?> valueSer) {
+        if (refType == valueType && typeSer == valueTypeSerializer && valueSer == valueSerializer) {
+            return this;
+        }
+        return new OptionSerializer(refType, valueType, typeSer, valueSer, plainMode);
+    }
+
 }

--- a/src/main/java/io/vavr/jackson/datatype/serialize/VavrSerializers.java
+++ b/src/main/java/io/vavr/jackson/datatype/serialize/VavrSerializers.java
@@ -148,7 +148,7 @@ public class VavrSerializers extends Serializers.Base {
             return new LazySerializer(type);
         }
         if (Option.class.isAssignableFrom(raw)) {
-            return new OptionSerializer(type, settings.useOptionInPlainFormat());
+            return new OptionSerializer(type, type.getContentType(), contentTypeSerializer, contentValueSerializer, settings.useOptionInPlainFormat());
         }
         return super.findReferenceSerializer(config, type, beanDesc, contentTypeSerializer, contentValueSerializer);
     }

--- a/src/test/java/io/vavr/jackson/datatype/Issue141Test.java
+++ b/src/test/java/io/vavr/jackson/datatype/Issue141Test.java
@@ -1,0 +1,97 @@
+package io.vavr.jackson.datatype;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.vavr.control.Option;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.YearMonth;
+import java.util.Optional;
+
+public class Issue141Test extends BaseTest {
+
+    static class MyJavaOptionalClass {
+        @JsonProperty("operatingMonth")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM-yyyy")
+        Optional<YearMonth> operatingMonth;
+    }
+
+    @Test
+    public void itShouldSerializeJavaOptionalYearMonthAsString() throws IOException {
+        // Given an instance with java.util.Optional
+        MyJavaOptionalClass obj = new MyJavaOptionalClass();
+        obj.operatingMonth = Optional.of(YearMonth.of(2019, 12));
+
+        // When serializing the instance using object mapper
+        // with Java Time Module and JDK8 Module
+        ObjectMapper objectMapper = mapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.registerModule(new Jdk8Module());
+        String json = objectMapper.writeValueAsString(obj);
+
+        // Then serialization is successful
+        Assert.assertEquals("{\"operatingMonth\":\"12-2019\"}", json);
+
+        // And deserialization is successful
+        MyJavaOptionalClass obj2 = objectMapper.readValue(json, MyJavaOptionalClass.class);
+        Assert.assertEquals(Optional.of(YearMonth.of(2019, 12)), obj2.operatingMonth);
+    }
+
+    static class MyVavrOptionalClassWithoutFormat {
+        @JsonProperty("operatingMonth")
+        Option<YearMonth> operatingMonth;
+    }
+
+    @Test
+    public void itShouldSerializeVavrOptionYearMonthAsStringWithoutJsonFormat() throws IOException {
+        // Given an instance with io.vavr.control.Option
+        MyVavrOptionalClassWithoutFormat obj = new MyVavrOptionalClassWithoutFormat();
+        obj.operatingMonth = Option.of(YearMonth.of(2019, 12));
+
+        // When serializing the instance using object mapper
+        // with Java Time Module and VAVR Module
+        ObjectMapper objectMapper = mapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.registerModule(new VavrModule());
+        String json = objectMapper.writeValueAsString(obj);
+
+        // Then serialization is successful
+        Assert.assertEquals("{\"operatingMonth\":[2019,12]}", json);
+        MyVavrOptionalClassWithoutFormat obj2 = objectMapper.readValue(json, MyVavrOptionalClassWithoutFormat.class);
+
+        // And deserialization is successful
+        Assert.assertEquals(Option.of(YearMonth.of(2019, 12)), obj2.operatingMonth);
+    }
+
+    static class MyVavrOptionClassWithFormat {
+        @JsonProperty("operatingMonth")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM-yyyy")
+        Option<YearMonth> operatingMonth;
+    }
+
+    @Test
+    public void itShouldSerializeVavrOptionYearMonthAsString() throws IOException {
+        // Given an instance with io.vavr.control.Option
+        MyVavrOptionClassWithFormat obj = new MyVavrOptionClassWithFormat();
+        obj.operatingMonth = Option.of(YearMonth.of(2019, 12));
+
+        // When serializing the instance using object mapper
+        // with Java Time Module and VAVR Module
+        ObjectMapper objectMapper = mapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.registerModule(new VavrModule());
+        String json = objectMapper.writeValueAsString(obj);
+
+        // Then serialization is failed
+        Assert.assertEquals("{\"operatingMonth\":\"12-2019\"}", json);
+        MyVavrOptionClassWithFormat obj2 = objectMapper.readValue(json, MyVavrOptionClassWithFormat.class);
+
+        // And deserialization is failed
+        Assert.assertEquals(Option.of(YearMonth.of(2019, 12)), obj2.operatingMonth);
+    }
+}


### PR DESCRIPTION
Contextualization provides support for property annotations. [ContextualSerializer](https://github.com/FasterXML/jackson-databind/blob/2.11/src/main/java/com/fasterxml/jackson/databind/ser/ContextualSerializer.java) and [ContextualDeserializer](https://github.com/FasterXML/jackson-databind/blob/2.11/src/main/java/com/fasterxml/jackson/databind/deser/ContextualDeserializer.java) are add-on interfaces that `JsonSerializer` and `JsonDeserializer` can implement to get a callback that can be used to create contextual instances to use for handling properties of supported type. My changes are mainly guided by [OptionalSerializer](https://github.com/FasterXML/jackson-modules-java8/blob/2.11/datatypes/src/main/java/com/fasterxml/jackson/datatype/jdk8/OptionalSerializer.java) and [OptionalDeserializer](https://github.com/FasterXML/jackson-modules-java8/blob/2.11/datatypes/src/main/java/com/fasterxml/jackson/datatype/jdk8/OptionalDeserializer.java) of Jackson Datatype JDK8.

This PR fixes #141