### PR TITLE
Add checkstyle to project and avoid unused import statements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'maven'
     id 'jacoco'
+    id 'checkstyle'
     id 'com.bmuschko.nexus' version '2.3.1'
 }
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="UnusedImports"/>
+    </module>
+</module>

--- a/src/test/java/generator/BindingClass.java
+++ b/src/test/java/generator/BindingClass.java
@@ -85,6 +85,7 @@ public class BindingClass {
 
         JavaFile javaFile = JavaFile.builder("io.vavr.jackson.generated", pojoTest.build())
                 .indent("    ")
+                .skipJavaLangImports(true)
                 .build();
 
         javaFile.writeTo(new File("src/test/java"));

--- a/src/test/java/generator/ExtFieldsPojo.java
+++ b/src/test/java/generator/ExtFieldsPojo.java
@@ -131,6 +131,7 @@ public class ExtFieldsPojo {
 
         JavaFile javaFile = JavaFile.builder("io.vavr.jackson.generated", pojoTest.build())
                 .indent("    ")
+                .skipJavaLangImports(true)
                 .build();
 
         javaFile.writeTo(new File("src/test/java"));

--- a/src/test/java/generator/ParameterizedPojo.java
+++ b/src/test/java/generator/ParameterizedPojo.java
@@ -3,11 +3,9 @@ package generator;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.squareup.javapoet.*;
 import io.vavr.*;
-import io.vavr.collection.List;
 import io.vavr.collection.Map;
 import io.vavr.collection.Multimap;
 import io.vavr.control.Either;
-import io.vavr.control.Option;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -45,6 +43,7 @@ public class ParameterizedPojo {
 
         JavaFile javaFile = JavaFile.builder("io.vavr.jackson.generated", pojoTest.build())
                 .indent("    ")
+                .skipJavaLangImports(true)
                 .build();
 
         javaFile.writeTo(new File("src/test/java"));

--- a/src/test/java/generator/PolymorphicPojo.java
+++ b/src/test/java/generator/PolymorphicPojo.java
@@ -123,6 +123,7 @@ public class PolymorphicPojo {
 
         JavaFile javaFile = JavaFile.builder("io.vavr.jackson.generated", pojoTest.build())
                 .indent("    ")
+                .skipJavaLangImports(true)
                 .build();
 
         javaFile.writeTo(new File("src/test/java"));

--- a/src/test/java/generator/SimplePojo.java
+++ b/src/test/java/generator/SimplePojo.java
@@ -36,6 +36,7 @@ public class SimplePojo {
 
         JavaFile javaFile = JavaFile.builder("io.vavr.jackson.generated", pojoTest.build())
                 .indent("    ")
+                .skipJavaLangImports(true)
                 .build();
 
         javaFile.writeTo(new File("src/test/java"));

--- a/src/test/java/generator/utils/Initializer.java
+++ b/src/test/java/generator/utils/Initializer.java
@@ -9,7 +9,6 @@ import io.vavr.control.Option;
 import io.vavr.jackson.datatype.VavrModule;
 
 import javax.lang.model.element.Modifier;
-import java.util.Arrays;
 
 /**
  * @author <a href="mailto:ruslan.sennov@gmail.com">Ruslan Sennov</a>

--- a/src/test/java/io/vavr/jackson/datatype/set/SetTest.java
+++ b/src/test/java/io/vavr/jackson/datatype/set/SetTest.java
@@ -1,7 +1,6 @@
 package io.vavr.jackson.datatype.set;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;

--- a/src/test/java/io/vavr/jackson/generated/BindingClassTest.java
+++ b/src/test/java/io/vavr/jackson/generated/BindingClassTest.java
@@ -14,10 +14,6 @@ import io.vavr.collection.List;
 import io.vavr.control.Either;
 import io.vavr.control.Option;
 import io.vavr.jackson.datatype.VavrModule;
-import java.lang.Exception;
-import java.lang.Integer;
-import java.lang.Override;
-import java.lang.String;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/io/vavr/jackson/generated/ExtFieldsPojoTest.java
+++ b/src/test/java/io/vavr/jackson/generated/ExtFieldsPojoTest.java
@@ -31,9 +31,6 @@ import io.vavr.collection.Vector;
 import io.vavr.control.Either;
 import io.vavr.control.Option;
 import io.vavr.jackson.datatype.VavrModule;
-import java.lang.Comparable;
-import java.lang.Exception;
-import java.lang.String;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/io/vavr/jackson/generated/ParameterizedPojoTest.java
+++ b/src/test/java/io/vavr/jackson/generated/ParameterizedPojoTest.java
@@ -30,10 +30,6 @@ import io.vavr.collection.Vector;
 import io.vavr.control.Either;
 import io.vavr.control.Option;
 import io.vavr.jackson.datatype.VavrModule;
-import java.lang.Exception;
-import java.lang.Integer;
-import java.lang.Object;
-import java.lang.String;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/io/vavr/jackson/generated/PolymorphicPojoTest.java
+++ b/src/test/java/io/vavr/jackson/generated/PolymorphicPojoTest.java
@@ -31,9 +31,6 @@ import io.vavr.collection.Vector;
 import io.vavr.control.Either;
 import io.vavr.control.Option;
 import io.vavr.jackson.datatype.VavrModule;
-import java.lang.Comparable;
-import java.lang.Exception;
-import java.lang.String;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/io/vavr/jackson/generated/SimplePojoTest.java
+++ b/src/test/java/io/vavr/jackson/generated/SimplePojoTest.java
@@ -29,10 +29,6 @@ import io.vavr.collection.Vector;
 import io.vavr.control.Either;
 import io.vavr.control.Option;
 import io.vavr.jackson.datatype.VavrModule;
-import java.lang.Exception;
-import java.lang.Integer;
-import java.lang.Object;
-import java.lang.String;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Recently when contributing to VAVR Jackson, I found several unused import statements. I propose we use [Gradle Checkstyle Plugin](https://docs.gradle.org/current/userguide/checkstyle_plugin.html) to detect it in the build.