### PR TITLE
Update serialization/deserialization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,18 @@ Just register a new instance of <code>VavrModule</code>
 ObjectMapper mapper = new ObjectMapper();
 mapper.registerModule(new VavrModule());
 ```
+
 ### Serialization/deserialization
+
+<!-- see io.vavr.jackson.datatype.docs.ReadmeTest#testDeser -->
+
 ```java
-String json = mapper.writer().writeValueAsString(List.of(List.of(1)));
-// = [[1]]
-Object restored1 = mapper.readValue(json, List.class);
-// = List(java.util.ArrayList(1))
-Object restored2 = mapper.readValue(json, new TypeReference<List<List<?>>>() {});
-// = List(List(1))
+String json = mapper.writeValueAsString(List.of(1));
+// = [1]
+List<Integer> restored = mapper.readValue(json, new TypeReference<List<Integer>>() {});
+// = List(1)
 ```
+
 ## Using Developer Versions
 
 Developer versions can be found [here](https://oss.sonatype.org/content/repositories/snapshots/io/vavr/vavr-jackson).

--- a/src/test/java/io/vavr/jackson/datatype/docs/ReadmeTest.java
+++ b/src/test/java/io/vavr/jackson/datatype/docs/ReadmeTest.java
@@ -1,0 +1,26 @@
+package io.vavr.jackson.datatype.docs;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vavr.collection.List;
+import io.vavr.jackson.datatype.BaseTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ReadmeTest extends BaseTest {
+
+    @Test
+    void testDeser() throws Exception {
+        ObjectMapper mapper = mapper();
+
+        // readme: Serialization/deserialization
+        String json = mapper.writeValueAsString(List.of(1));
+        List<Integer> restored = mapper.readValue(json, new TypeReference<List<Integer>>() {});
+        // end of readme
+
+        assertEquals("[1]", json);
+        assertEquals(List.of(1), restored);
+        assertEquals("List(1)", restored.toString());
+    }
+}


### PR DESCRIPTION
Use a simpler and type-safe example in README for serialization and deserialization.