### PR TITLE
Collection serializers and deserializer should be contextual

### DIFF
--- a/src/main/java/io/vavr/jackson/datatype/deserialize/SeqDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/SeqDeserializer.java
@@ -19,15 +19,9 @@
  */
 package io.vavr.jackson.datatype.deserialize;
 
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import io.vavr.collection.Array;
-import io.vavr.collection.IndexedSeq;
-import io.vavr.collection.Queue;
-import io.vavr.collection.Seq;
-import io.vavr.collection.Stream;
-import io.vavr.collection.Vector;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import io.vavr.collection.*;
 
 import java.util.List;
 
@@ -35,31 +29,48 @@ class SeqDeserializer extends ArrayDeserializer<Seq<?>> {
 
     private static final long serialVersionUID = 1L;
 
-    private final JavaType javaType;
+    SeqDeserializer(JavaType collectionType, JavaType elementType, TypeDeserializer elementTypeDeserializer,
+                    JsonDeserializer<?> elementDeserializer, boolean deserializeNullAsEmptyCollection) {
+        super(collectionType, 1, elementType, elementTypeDeserializer, elementDeserializer, deserializeNullAsEmptyCollection);
+    }
 
-    SeqDeserializer(JavaType valueType, boolean deserializeNullAsEmptyCollection) {
-        super(valueType, 1, deserializeNullAsEmptyCollection);
-        javaType = valueType;
+    /**
+     * Creates a new deserializer from the original one.
+     *
+     * @param origin                  the original deserializer
+     * @param elementTypeDeserializer the new deserializer for the element type
+     * @param elementDeserializer     the new deserializer for the element itself
+     */
+    private SeqDeserializer(SeqDeserializer origin, TypeDeserializer elementTypeDeserializer,
+                            JsonDeserializer<?> elementDeserializer) {
+        this(origin.collectionType, origin.elementType, elementTypeDeserializer, elementDeserializer,
+                origin.deserializeNullAsEmptyCollection);
     }
 
     @Override
     Seq<?> create(List<Object> result, DeserializationContext ctxt) throws JsonMappingException {
-        if (Array.class.isAssignableFrom(javaType.getRawClass())) {
+        if (Array.class.isAssignableFrom(collectionType.getRawClass())) {
             return Array.ofAll(result);
         }
-        if (Queue.class.isAssignableFrom(javaType.getRawClass())) {
+        if (Queue.class.isAssignableFrom(collectionType.getRawClass())) {
             return Queue.ofAll(result);
         }
-        if (Stream.class.isAssignableFrom(javaType.getRawClass())) {
+        if (Stream.class.isAssignableFrom(collectionType.getRawClass())) {
             return Stream.ofAll(result);
         }
-        if (Vector.class.isAssignableFrom(javaType.getRawClass())) {
+        if (Vector.class.isAssignableFrom(collectionType.getRawClass())) {
             return Vector.ofAll(result);
         }
-        if (IndexedSeq.class.isAssignableFrom(javaType.getRawClass())) {
+        if (IndexedSeq.class.isAssignableFrom(collectionType.getRawClass())) {
             return Array.ofAll(result);
         }
         // default deserialization [...] -> Seq
         return io.vavr.collection.List.ofAll(result);
     }
+
+    @Override
+    SeqDeserializer createDeserializer(TypeDeserializer elementTypeDeserializer, JsonDeserializer<?> elementDeserializer) {
+        return new SeqDeserializer(this, elementTypeDeserializer, elementDeserializer);
+    }
+
 }

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/VavrDeserializers.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/VavrDeserializers.java
@@ -152,25 +152,28 @@ public class VavrDeserializers extends Deserializers.Base {
     }
 
     @Override
-    public JsonDeserializer<?> findCollectionLikeDeserializer(CollectionLikeType type,
+    public JsonDeserializer<?> findCollectionLikeDeserializer(CollectionLikeType collectionType,
                                                               DeserializationConfig config, BeanDescription beanDesc,
                                                               TypeDeserializer elementTypeDeserializer, JsonDeserializer<?> elementDeserializer)
             throws JsonMappingException
     {
-        Class<?> raw = type.getRawClass();
+        Class<?> raw = collectionType.getRawClass();
         if (raw == CharSeq.class) {
-            return new CharSeqDeserializer(type);
+            return new CharSeqDeserializer(collectionType);
         }
         if (Seq.class.isAssignableFrom(raw)) {
-            return new SeqDeserializer(type, settings.deserializeNullAsEmptyCollection());
+            return new SeqDeserializer(collectionType, collectionType.getContentType(), elementTypeDeserializer,
+                    elementDeserializer, settings.deserializeNullAsEmptyCollection());
         }
         if (Set.class.isAssignableFrom(raw)) {
-            return new SetDeserializer(type, settings.deserializeNullAsEmptyCollection());
+            return new SetDeserializer(collectionType, collectionType.getContentType(), elementTypeDeserializer,
+                    elementDeserializer, settings.deserializeNullAsEmptyCollection());
         }
         if (PriorityQueue.class.isAssignableFrom(raw)) {
-            return new PriorityQueueDeserializer(type, settings.deserializeNullAsEmptyCollection());
+            return new PriorityQueueDeserializer(collectionType, collectionType.getContentType(),
+                    elementTypeDeserializer, elementDeserializer, settings.deserializeNullAsEmptyCollection());
         }
-        return super.findCollectionLikeDeserializer(type, config, beanDesc, elementTypeDeserializer, elementDeserializer);
+        return super.findCollectionLikeDeserializer(collectionType, config, beanDesc, elementTypeDeserializer, elementDeserializer);
     }
 
     @Override

--- a/src/main/java/io/vavr/jackson/datatype/serialize/ArraySerializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/serialize/ArraySerializer.java
@@ -19,8 +19,8 @@
  */
 package io.vavr.jackson.datatype.serialize;
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.ser.ContextualSerializer;
 import com.fasterxml.jackson.databind.type.CollectionLikeType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.vavr.Value;
@@ -28,12 +28,26 @@ import io.vavr.Value;
 import java.io.IOException;
 import java.util.ArrayList;
 
-class ArraySerializer<T extends Value<?>> extends ValueSerializer<T> {
+class ArraySerializer<T extends Value<?>> extends ValueSerializer<T> implements ContextualSerializer {
 
     private static final long serialVersionUID = 1L;
 
-    ArraySerializer(JavaType type) {
-        super(type);
+    ArraySerializer(JavaType collectionType, BeanProperty property) {
+        super(collectionType, property);
+    }
+
+    ArraySerializer(JavaType collectionType) {
+        this(collectionType, null);
+    }
+
+    /**
+     * Creates a new serializer from the original one.
+     *
+     * @param origin   the original serializer
+     * @param property the new bean property
+     */
+    ArraySerializer(ArraySerializer<T> origin, BeanProperty property) {
+        this(origin.type, property);
     }
 
     @Override
@@ -50,5 +64,14 @@ class ArraySerializer<T extends Value<?>> extends ValueSerializer<T> {
     @Override
     public boolean isEmpty(SerializerProvider provider, T value) {
         return value.isEmpty();
+    }
+
+    @Override
+    public JsonSerializer<?> createContextual(SerializerProvider provider, BeanProperty property)
+            throws JsonMappingException {
+        if (property == beanProperty) {
+            return this;
+        }
+        return new ArraySerializer<>(this, property);
     }
 }

--- a/src/main/java/io/vavr/jackson/datatype/serialize/ValueSerializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/serialize/ValueSerializer.java
@@ -20,6 +20,7 @@
 package io.vavr.jackson.datatype.serialize;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -33,11 +34,17 @@ abstract class ValueSerializer<T> extends StdSerializer<T> {
 
     private static final long serialVersionUID = 1L;
 
-    JavaType type;
+    final JavaType type;
+    final BeanProperty beanProperty;
 
     ValueSerializer(JavaType type) {
+        this(type, null);
+    }
+
+    ValueSerializer(JavaType type, BeanProperty property) {
         super(type);
         this.type = type;
+        this.beanProperty = property;
     }
 
     abstract Object toJavaObj(T value) throws IOException;
@@ -53,12 +60,12 @@ abstract class ValueSerializer<T> extends StdSerializer<T> {
             try {
                 JavaType emulated = emulatedJavaType(type, provider.getTypeFactory());
                 if (emulated.getRawClass() != Object.class) {
-                    ser = provider.findTypedValueSerializer(emulated, true, null);
+                    ser = provider.findTypedValueSerializer(emulated, true, beanProperty);
                 } else {
-                    ser = provider.findTypedValueSerializer(obj.getClass(), true, null);
+                    ser = provider.findTypedValueSerializer(obj.getClass(), true, beanProperty);
                 }
             } catch (Exception ignore) {
-                ser = provider.findTypedValueSerializer(obj.getClass(), true, null);
+                ser = provider.findTypedValueSerializer(obj.getClass(), true, beanProperty);
             }
             ser.serialize(obj, gen, provider);
         }

--- a/src/main/java/io/vavr/jackson/datatype/serialize/VavrSerializers.java
+++ b/src/main/java/io/vavr/jackson/datatype/serialize/VavrSerializers.java
@@ -155,22 +155,22 @@ public class VavrSerializers extends Serializers.Base {
 
     @Override
     public JsonSerializer<?> findCollectionLikeSerializer(SerializationConfig config,
-                                                          CollectionLikeType type, BeanDescription beanDesc,
+                                                          CollectionLikeType collectionType, BeanDescription beanDesc,
                                                           TypeSerializer elementTypeSerializer, JsonSerializer<Object> elementValueSerializer) {
-        Class<?> raw = type.getRawClass();
+        Class<?> raw = collectionType.getRawClass();
         if (raw == CharSeq.class) {
-            return new CharSeqSerializer(type);
+            return new CharSeqSerializer(collectionType);
         }
         if (Seq.class.isAssignableFrom(raw)) {
-            return new ArraySerializer<>(type);
+            return new ArraySerializer<>(collectionType);
         }
         if (Set.class.isAssignableFrom(raw)) {
-            return new ArraySerializer<>(type);
+            return new ArraySerializer<>(collectionType);
         }
         if (PriorityQueue.class.isAssignableFrom(raw)) {
-            return new ArraySerializer<>(type);
+            return new ArraySerializer<>(collectionType);
         }
-        return super.findCollectionLikeSerializer(config, type, beanDesc, elementTypeSerializer, elementValueSerializer);
+        return super.findCollectionLikeSerializer(config, collectionType, beanDesc, elementTypeSerializer, elementValueSerializer);
     }
 
     @Override

--- a/src/test/java/io/vavr/jackson/datatype/Issue154Test.java
+++ b/src/test/java/io/vavr/jackson/datatype/Issue154Test.java
@@ -35,7 +35,7 @@ public class Issue154Test {
         mapper.registerModule(new VavrModule());
 
         String json = mapper.writeValueAsString(myClass);
-        assertEquals("{\"dates\":[1591221600000,1591308000000]}", json);
+        assertEquals("{\"dates\":[\"2020-06-04\",\"2020-06-05\"]}", json);
     }
 
     @Test
@@ -48,7 +48,7 @@ public class Issue154Test {
         mapper.registerModule(new JavaTimeModule());
 
         String json = mapper.writeValueAsString(myClass);
-        assertEquals("{\"dates\":[1591221600000,1591308000000]}", json);
+        assertEquals("{\"dates\":[\"2020-06-04\",\"2020-06-05\"]}", json);
     }
 
     @Test

--- a/src/test/java/io/vavr/jackson/datatype/Issue154Test.java
+++ b/src/test/java/io/vavr/jackson/datatype/Issue154Test.java
@@ -1,0 +1,76 @@
+package io.vavr.jackson.datatype;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.vavr.collection.List;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Serialize of List of Date does not follow pattern defined in {@code @JsonFormat}
+ * https://github.com/vavr-io/vavr-jackson/issues/154
+ */
+public class Issue154Test {
+
+    private static class MyVavrClass {
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Europe/Paris")
+        private List<Date> dates;
+    }
+
+    private static class MyJavaClass {
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Europe/Paris")
+        private java.util.List<Date> dates;
+    }
+
+    @Test
+    void itShouldSerializeVavrListWithVavrModule() throws Exception {
+        MyVavrClass myClass = new MyVavrClass();
+        myClass.dates = List.of(new Date(1591221600000L), new Date(1591308000000L));
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new VavrModule());
+
+        String json = mapper.writeValueAsString(myClass);
+        assertEquals("{\"dates\":[1591221600000,1591308000000]}", json);
+    }
+
+    @Test
+    void itShouldSerializeVavrListWithVavrModuleAndJavaTimeModule() throws Exception {
+        MyVavrClass myClass = new MyVavrClass();
+        myClass.dates = List.of(new Date(1591221600000L), new Date(1591308000000L));
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new VavrModule());
+        mapper.registerModule(new JavaTimeModule());
+
+        String json = mapper.writeValueAsString(myClass);
+        assertEquals("{\"dates\":[1591221600000,1591308000000]}", json);
+    }
+
+    @Test
+    void itShouldSerializeJavaListWithJavaTimeModule() throws Exception {
+        MyJavaClass myClass = new MyJavaClass();
+        myClass.dates = List.of(new Date(1591221600000L), new Date(1591308000000L)).asJava();
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+
+        String json = mapper.writeValueAsString(myClass);
+        assertEquals("{\"dates\":[\"2020-06-04\",\"2020-06-05\"]}", json);
+    }
+
+    @Test
+    void itShouldSerializeJavaListWithoutModule() throws Exception {
+        MyJavaClass myClass = new MyJavaClass();
+        myClass.dates = List.of(new Date(1591221600000L), new Date(1591308000000L)).asJava();
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        String json = mapper.writeValueAsString(myClass);
+        assertEquals("{\"dates\":[\"2020-06-04\",\"2020-06-05\"]}", json);
+    }
+}

--- a/src/test/java/io/vavr/jackson/datatype/seq/ArrayTest.java
+++ b/src/test/java/io/vavr/jackson/datatype/seq/ArrayTest.java
@@ -1,12 +1,18 @@
 package io.vavr.jackson.datatype.seq;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.type.TypeReference;
-
-import java.util.Arrays;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.vavr.collection.Array;
 import io.vavr.collection.Seq;
 import io.vavr.control.Option;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Date;
 
 public class ArrayTest extends SeqTest {
     @Override
@@ -22,5 +28,29 @@ public class ArrayTest extends SeqTest {
     @Override
     protected Seq<?> of(Object... objects) {
         return Array.ofAll(Arrays.asList(objects));
+    }
+
+    static class FrenchDates {
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/yyyy", timezone = "Europe/Paris")
+        Array<Date> dates;
+    }
+
+    @Test
+    void testSerializeWithContext() throws IOException {
+        // Given an object containing dates to serialize
+        FrenchDates src = new FrenchDates();
+        src.dates = Array.of(new Date(1591308000000L));
+
+        // When serializing them using object mapper
+        // with VAVR module and Java Time module
+        ObjectMapper mapper = mapper().registerModule(new JavaTimeModule());
+        String json = mapper.writeValueAsString(src);
+
+        // Then the serialization is successful
+        Assertions.assertEquals("{\"dates\":[\"05/06/2020\"]}", json);
+
+        // And the deserialization is successful
+        FrenchDates restored = mapper.readValue(json, FrenchDates.class);
+        Assertions.assertEquals(src.dates, restored.dates);
     }
 }

--- a/src/test/java/io/vavr/jackson/datatype/seq/ListTest.java
+++ b/src/test/java/io/vavr/jackson/datatype/seq/ListTest.java
@@ -1,8 +1,11 @@
 package io.vavr.jackson.datatype.seq;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import io.vavr.control.Option;
@@ -11,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Date;
 
 public class ListTest extends SeqTest {
 
@@ -62,6 +66,30 @@ public class ListTest extends SeqTest {
         Assertions.assertEquals(mapper().writeValueAsString(new B()), javaUtilValue);
         A restored = mapper().readValue(javaUtilValue, A.class);
         Assertions.assertEquals("hello", restored.f.head().type);
+    }
+
+    static class FrenchDates {
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/yyyy", timezone = "Europe/Paris")
+        List<Date> dates;
+    }
+
+    @Test
+    void testSerializeWithContext() throws IOException {
+        // Given an object containing dates to serialize
+        FrenchDates src = new FrenchDates();
+        src.dates = List.of(new Date(1591308000000L));
+
+        // When serializing them using object mapper
+        // with VAVR module and Java Time module
+        ObjectMapper mapper = mapper().registerModule(new JavaTimeModule());
+        String json = mapper.writeValueAsString(src);
+
+        // Then the serialization is successful
+        Assertions.assertEquals("{\"dates\":[\"05/06/2020\"]}", json);
+
+        // And the deserialization is successful
+        FrenchDates restored = mapper.readValue(json, FrenchDates.class);
+        Assertions.assertEquals(src.dates, restored.dates);
     }
 
 }

--- a/src/test/java/io/vavr/jackson/datatype/set/HashSetTest.java
+++ b/src/test/java/io/vavr/jackson/datatype/set/HashSetTest.java
@@ -1,16 +1,18 @@
 package io.vavr.jackson.datatype.set;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.type.TypeReference;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.vavr.collection.HashSet;
+import io.vavr.collection.Set;
+import io.vavr.control.Option;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
-
-import io.vavr.collection.HashSet;
-import io.vavr.collection.Set;
-import io.vavr.control.Option;
+import java.util.Date;
 
 public class HashSetTest extends SetTest {
 
@@ -37,5 +39,29 @@ public class HashSetTest extends SetTest {
     @Test
     void testDefaultDeserialization() throws IOException {
         Assertions.assertEquals(mapper().readValue("[1]", Set.class), HashSet.of(1));
+    }
+
+    static class FrenchDates {
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/yyyy", timezone = "Europe/Paris")
+        Set<Date> dates;
+    }
+
+    @Test
+    void testSerializeWithContext() throws IOException {
+        // Given an object containing dates to serialize
+        FrenchDates src = new FrenchDates();
+        src.dates = HashSet.of(new Date(1591308000000L));
+
+        // When serializing them using object mapper
+        // with VAVR module and Java Time module
+        ObjectMapper mapper = mapper().registerModule(new JavaTimeModule());
+        String json = mapper.writeValueAsString(src);
+
+        // Then the serialization is successful
+        Assertions.assertEquals("{\"dates\":[\"05/06/2020\"]}", json);
+
+        // And the deserialization is successful
+        FrenchDates restored = mapper.readValue(json, FrenchDates.class);
+        Assertions.assertEquals(src.dates, restored.dates);
     }
 }


### PR DESCRIPTION
## Overview

Fix #154 

Collection-like serializers and deserializers should be contextual to handle properties of the element defined outside of the collection. For example, in collection `List<Date>`, handling `@JsonFormat` defined for `Date`:

```java
class FrenchDates {
    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/yyyy", timezone = "Europe/Paris")
    List<Date> dates;
}
```

All the collection-like serializers and deserializers are concerned: serializers and deserializers for Set, Seq, Array, Priority-Queue, List, and their derived classes.

## Serialization

VAVR-Jackson does not handle the serialization directly. We emulate the VAVR type to Java type. Then, let the serializer provider to find the right serializer to handle the logic. To support contextualization, we save the bean property in `ArraySerializer`, and pass this property to serializer provider for the lookup:

```diff
-                    ser = provider.findTypedValueSerializer(emulated, true, null);
+                    ser = provider.findTypedValueSerializer(emulated, true, beanProperty);
```

Since serializer should be immutable ([see comment](https://github.com/FasterXML/jackson-databind/issues/1114#issuecomment-569121351)), by "saving the bean property", it actually means creating a new serializer with all the existing info and a new bean property.

## Deserialization

VAVR-Jackson handles the deserialization directly. In Array-Deserializer, implement the add-on interface `ContextualDeserializer` and perform lookup to find the appropriated serializer for the elements of the collection. The logic is mainly inspired from previous PRs (https://github.com/vavr-io/vavr-jackson/pull/144, https://github.com/vavr-io/vavr-jackson/pull/147) and Jackson Databind.

## Additional Notes

Other serializers and deserializers may have the same problem. I need to spend some time to them in future PRs...