### PR TITLE
Cleanup: move issue tests to separated package 

### DIFF
--- a/src/test/java/io/vavr/jackson/issues/Issue141Test.java
+++ b/src/test/java/io/vavr/jackson/issues/Issue141Test.java
@@ -1,4 +1,4 @@
-package io.vavr.jackson.datatype;
+package io.vavr.jackson.issues;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.vavr.control.Option;
+import io.vavr.jackson.datatype.BaseTest;
+import io.vavr.jackson.datatype.VavrModule;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/io/vavr/jackson/issues/Issue142Test.java
+++ b/src/test/java/io/vavr/jackson/issues/Issue142Test.java
@@ -1,4 +1,4 @@
-package io.vavr.jackson.datatype;
+package io.vavr.jackson.issues;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -8,13 +8,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.vavr.collection.TreeMap;
 import io.vavr.collection.TreeMultimap;
+import io.vavr.jackson.datatype.BaseTest;
+import io.vavr.jackson.datatype.VavrModule;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-public class Iss142Test extends BaseTest {
+public class Issue142Test extends BaseTest {
 
     public static class MyComparable implements Comparable<MyComparable> {
 

--- a/src/test/java/io/vavr/jackson/issues/Issue154Test.java
+++ b/src/test/java/io/vavr/jackson/issues/Issue154Test.java
@@ -1,9 +1,10 @@
-package io.vavr.jackson.datatype;
+package io.vavr.jackson.issues;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.vavr.collection.List;
+import io.vavr.jackson.datatype.VavrModule;
 import org.junit.jupiter.api.Test;
 
 import java.util.Date;


### PR DESCRIPTION
> ⚠️ Please review https://github.com/vavr-io/vavr-jackson/pull/155 first

Move all the regression tests (issue tests) to package `io.vavr.jackson.issues` to have a better separation. Also, rename existing tests to be `Issue{id}Test`. Only the last commit is relevant.