### PR TITLE
Serializer and deserializer of Map and Multimap should be contextual

### DIFF
--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MapDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MapDeserializer.java
@@ -22,6 +22,7 @@ package io.vavr.jackson.datatype.deserialize;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.type.MapLikeType;
 import io.vavr.Tuple;
@@ -38,13 +39,13 @@ class MapDeserializer extends MaplikeDeserializer<Map<?, ?>> {
         super(mapType, keyDeserializer);
     }
 
-    MapDeserializer(MapDeserializer origin, KeyDeserializer keyDeserializer) {
-        super(origin.mapType, origin.keyComparator, keyDeserializer, origin.valueDeserializer);
+    MapDeserializer(MapDeserializer origin, KeyDeserializer keyDeserializer, JsonDeserializer<?> valueDeserializer) {
+        super(origin.mapType, origin.keyComparator, keyDeserializer, valueDeserializer);
     }
 
     @Override
-    MaplikeDeserializer<Map<?, ?>> createDeserializer(KeyDeserializer keyDeserializer) {
-        return new MapDeserializer(this, keyDeserializer);
+    MaplikeDeserializer<Map<?, ?>> createDeserializer(KeyDeserializer keyDeserializer, JsonDeserializer<?> valueDeserializer) {
+        return new MapDeserializer(this, keyDeserializer, valueDeserializer);
     }
 
     @Override

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MapDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MapDeserializer.java
@@ -38,6 +38,15 @@ class MapDeserializer extends MaplikeDeserializer<Map<?, ?>> {
         super(mapType, keyDeserializer);
     }
 
+    MapDeserializer(MapDeserializer origin, KeyDeserializer keyDeserializer) {
+        super(origin.mapType, origin.keyComparator, keyDeserializer, origin.valueDeserializer);
+    }
+
+    @Override
+    MaplikeDeserializer<Map<?, ?>> createDeserializer(KeyDeserializer keyDeserializer) {
+        return new MapDeserializer(this, keyDeserializer);
+    }
+
     @Override
     public Map<?, ?> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         final java.util.List<Tuple2<Object, Object>> result = new java.util.ArrayList<>();

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MapDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MapDeserializer.java
@@ -22,6 +22,7 @@ package io.vavr.jackson.datatype.deserialize;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.type.MapLikeType;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
@@ -33,8 +34,8 @@ class MapDeserializer extends MaplikeDeserializer<Map<?, ?>> {
 
     private static final long serialVersionUID = 1L;
 
-    MapDeserializer(MapLikeType mapType) {
-        super(mapType);
+    MapDeserializer(MapLikeType mapType, KeyDeserializer keyDeserializer) {
+        super(mapType, keyDeserializer);
     }
 
     @Override

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MapDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MapDeserializer.java
@@ -22,7 +22,7 @@ package io.vavr.jackson.datatype.deserialize;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.MapLikeType;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
 import io.vavr.collection.*;
@@ -33,8 +33,8 @@ class MapDeserializer extends MaplikeDeserializer<Map<?, ?>> {
 
     private static final long serialVersionUID = 1L;
 
-    MapDeserializer(JavaType valueType) {
-        super(valueType);
+    MapDeserializer(MapLikeType mapType) {
+        super(mapType);
     }
 
     @Override

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MapDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MapDeserializer.java
@@ -35,8 +35,8 @@ class MapDeserializer extends MaplikeDeserializer<Map<?, ?>> {
 
     private static final long serialVersionUID = 1L;
 
-    MapDeserializer(MapLikeType mapType, KeyDeserializer keyDeserializer) {
-        super(mapType, keyDeserializer);
+    MapDeserializer(MapLikeType mapType, KeyDeserializer keyDeserializer, JsonDeserializer<?> valueDeserializer) {
+        super(mapType, keyDeserializer, valueDeserializer);
     }
 
     MapDeserializer(MapDeserializer origin, KeyDeserializer keyDeserializer, JsonDeserializer<?> valueDeserializer) {

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MaplikeDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MaplikeDeserializer.java
@@ -38,11 +38,11 @@ abstract class MaplikeDeserializer<T> extends StdDeserializer<T> implements Reso
     final KeyDeserializer keyDeserializer;
     final JsonDeserializer<?> valueDeserializer;
 
-    MaplikeDeserializer(MapLikeType mapType, KeyDeserializer keyDeserializer) {
+    MaplikeDeserializer(MapLikeType mapType, KeyDeserializer keyDeserializer, JsonDeserializer<?> valueDeserializer) {
         super(mapType);
         this.mapType = mapType;
         this.keyDeserializer = keyDeserializer;
-        this.valueDeserializer = null;
+        this.valueDeserializer = valueDeserializer;
     }
 
     MaplikeDeserializer(MapLikeType mapType, Comparator<Object> keyComparator, KeyDeserializer keyDeserializer,
@@ -84,6 +84,8 @@ abstract class MaplikeDeserializer<T> extends StdDeserializer<T> implements Reso
         JsonDeserializer<?> valueDeser = valueDeserializer;
         if (valueDeser == null) {
             valueDeser = context.findContextualValueDeserializer(mapType.getContentType(), property);
+        } else {
+            valueDeser = context.handleSecondaryContextualization(valueDeser, property, mapType.getContentType());
         }
         return createDeserializer(keyDeser, valueDeser);
     }

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MaplikeDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MaplikeDeserializer.java
@@ -31,27 +31,28 @@ abstract class MaplikeDeserializer<T> extends StdDeserializer<T> implements Reso
 
     private static final long serialVersionUID = 1L;
 
-    final MapLikeType javaType;
+    final MapLikeType mapType;
 
     Comparator<Object> keyComparator;
     KeyDeserializer keyDeserializer;
     JsonDeserializer<?> valueDeserializer;
 
-    MaplikeDeserializer(JavaType valueType) {
-        super(valueType);
-        this.javaType = (MapLikeType) valueType;
+    MaplikeDeserializer(MapLikeType mapType) {
+        super(mapType);
+        this.mapType = mapType;
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public void resolve(DeserializationContext ctxt) throws JsonMappingException {
-        JavaType keyType = javaType.getKeyType();
+        JavaType keyType = mapType.getKeyType();
         if (Comparable.class.isAssignableFrom(keyType.getRawClass())) {
             keyComparator = (Comparator<Object> & Serializable) (o1, o2) -> ((Comparable<Object>) o1).compareTo(o2);
         } else {
             keyComparator = (Comparator<Object> & Serializable) (o1, o2) -> o1.toString().compareTo(o2.toString());
         }
         keyDeserializer = ctxt.findKeyDeserializer(keyType, null);
-        valueDeserializer = ctxt.findRootValueDeserializer(javaType.getContentType());
+        valueDeserializer = ctxt.findRootValueDeserializer(mapType.getContentType());
     }
+
 }

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MaplikeDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MaplikeDeserializer.java
@@ -37,9 +37,10 @@ abstract class MaplikeDeserializer<T> extends StdDeserializer<T> implements Reso
     KeyDeserializer keyDeserializer;
     JsonDeserializer<?> valueDeserializer;
 
-    MaplikeDeserializer(MapLikeType mapType) {
+    MaplikeDeserializer(MapLikeType mapType, KeyDeserializer keyDeserializer) {
         super(mapType);
         this.mapType = mapType;
+        this.keyDeserializer = keyDeserializer;
     }
 
     @SuppressWarnings("unchecked")
@@ -51,7 +52,9 @@ abstract class MaplikeDeserializer<T> extends StdDeserializer<T> implements Reso
         } else {
             keyComparator = (Comparator<Object> & Serializable) (o1, o2) -> o1.toString().compareTo(o2.toString());
         }
-        keyDeserializer = ctxt.findKeyDeserializer(keyType, null);
+        if (keyDeserializer == null) {
+            keyDeserializer = ctxt.findKeyDeserializer(keyType, null);
+        }
         valueDeserializer = ctxt.findRootValueDeserializer(mapType.getContentType());
     }
 

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MaplikeDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MaplikeDeserializer.java
@@ -21,6 +21,7 @@ package io.vavr.jackson.datatype.deserialize;
 
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.ContextualKeyDeserializer;
 import com.fasterxml.jackson.databind.deser.ResolvableDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.type.MapLikeType;
@@ -79,6 +80,8 @@ abstract class MaplikeDeserializer<T> extends StdDeserializer<T> implements Reso
         KeyDeserializer keyDeser = keyDeserializer;
         if (keyDeser == null) {
             keyDeser = context.findKeyDeserializer(mapType.getKeyType(), property);
+        } else if (keyDeser instanceof ContextualKeyDeserializer) {
+            keyDeser = ((ContextualKeyDeserializer) keyDeser).createContextual(context, property);
         }
 
         JsonDeserializer<?> valueDeser = valueDeserializer;

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MultimapDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MultimapDeserializer.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.type.MapLikeType;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
 import io.vavr.collection.HashMultimap;
@@ -41,14 +42,14 @@ class MultimapDeserializer extends MaplikeDeserializer<Multimap<?, ?>> {
 
     private JsonDeserializer<?> containerDeserializer;
 
-    MultimapDeserializer(JavaType valueType) {
-        super(valueType);
+    MultimapDeserializer(MapLikeType mapType) {
+        super(mapType);
     }
 
     @Override
     public void resolve(DeserializationContext ctxt) throws JsonMappingException {
         super.resolve(ctxt);
-        JavaType containerType = ctxt.getTypeFactory().constructCollectionType(ArrayList.class, javaType.getContentType());
+        JavaType containerType = ctxt.getTypeFactory().constructCollectionType(ArrayList.class, mapType.getContentType());
         containerDeserializer = ctxt.findContextualValueDeserializer(containerType, null);
     }
 

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MultimapDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MultimapDeserializer.java
@@ -22,6 +22,7 @@ package io.vavr.jackson.datatype.deserialize;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.type.MapLikeType;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
@@ -39,18 +40,21 @@ class MultimapDeserializer extends MaplikeDeserializer<Multimap<?, ?>> {
 
     private JsonDeserializer<?> containerDeserializer;
 
-    MultimapDeserializer(MapLikeType mapType, KeyDeserializer keyDeserializer, JsonDeserializer<?> valueDeserializer) {
-        super(mapType, keyDeserializer, valueDeserializer);
+    MultimapDeserializer(MapLikeType mapType, KeyDeserializer keyDeserializer, TypeDeserializer elementTypeDeserializer,
+                         JsonDeserializer<?> elementDeserializer) {
+        super(mapType, null, keyDeserializer, elementTypeDeserializer, elementDeserializer);
     }
 
-    MultimapDeserializer(MultimapDeserializer origin, KeyDeserializer keyDeserializer, JsonDeserializer<?> valueDeserializer) {
-        super(origin.mapType, origin.keyComparator, keyDeserializer, valueDeserializer);
+    MultimapDeserializer(MultimapDeserializer origin, KeyDeserializer keyDeserializer,
+                         TypeDeserializer elementTypeDeserializer, JsonDeserializer<?> elementDeserializer) {
+        super(origin.mapType, origin.keyComparator, keyDeserializer, elementTypeDeserializer, elementDeserializer);
         containerDeserializer = origin.containerDeserializer;
     }
 
     @Override
-    MultimapDeserializer createDeserializer(KeyDeserializer keyDeserializer, JsonDeserializer<?> valueDeserializer) {
-        return new MultimapDeserializer(this, keyDeserializer, valueDeserializer);
+    MultimapDeserializer createDeserializer(KeyDeserializer keyDeserializer, TypeDeserializer elementTypeDeserializer,
+                                            JsonDeserializer<?> elementDeserializer) {
+        return new MultimapDeserializer(this, keyDeserializer, elementTypeDeserializer, elementDeserializer);
     }
 
     @Override

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MultimapDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MultimapDeserializer.java
@@ -39,8 +39,8 @@ class MultimapDeserializer extends MaplikeDeserializer<Multimap<?, ?>> {
 
     private JsonDeserializer<?> containerDeserializer;
 
-    MultimapDeserializer(MapLikeType mapType, KeyDeserializer keyDeserializer) {
-        super(mapType, keyDeserializer);
+    MultimapDeserializer(MapLikeType mapType, KeyDeserializer keyDeserializer, JsonDeserializer<?> valueDeserializer) {
+        super(mapType, keyDeserializer, valueDeserializer);
     }
 
     MultimapDeserializer(MultimapDeserializer origin, KeyDeserializer keyDeserializer, JsonDeserializer<?> valueDeserializer) {

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MultimapDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MultimapDeserializer.java
@@ -21,10 +21,7 @@ package io.vavr.jackson.datatype.deserialize;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.type.MapLikeType;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
@@ -42,8 +39,8 @@ class MultimapDeserializer extends MaplikeDeserializer<Multimap<?, ?>> {
 
     private JsonDeserializer<?> containerDeserializer;
 
-    MultimapDeserializer(MapLikeType mapType) {
-        super(mapType);
+    MultimapDeserializer(MapLikeType mapType, KeyDeserializer keyDeserializer) {
+        super(mapType, keyDeserializer);
     }
 
     @Override

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MultimapDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MultimapDeserializer.java
@@ -43,14 +43,14 @@ class MultimapDeserializer extends MaplikeDeserializer<Multimap<?, ?>> {
         super(mapType, keyDeserializer);
     }
 
-    MultimapDeserializer(MultimapDeserializer origin, KeyDeserializer keyDeserializer) {
-        super(origin.mapType, origin.keyComparator, keyDeserializer, origin.valueDeserializer);
+    MultimapDeserializer(MultimapDeserializer origin, KeyDeserializer keyDeserializer, JsonDeserializer<?> valueDeserializer) {
+        super(origin.mapType, origin.keyComparator, keyDeserializer, valueDeserializer);
         containerDeserializer = origin.containerDeserializer;
     }
 
     @Override
-    MultimapDeserializer createDeserializer(KeyDeserializer keyDeserializer) {
-        return new MultimapDeserializer(this, keyDeserializer);
+    MultimapDeserializer createDeserializer(KeyDeserializer keyDeserializer, JsonDeserializer<?> valueDeserializer) {
+        return new MultimapDeserializer(this, keyDeserializer, valueDeserializer);
     }
 
     @Override

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MultimapDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MultimapDeserializer.java
@@ -43,6 +43,16 @@ class MultimapDeserializer extends MaplikeDeserializer<Multimap<?, ?>> {
         super(mapType, keyDeserializer);
     }
 
+    MultimapDeserializer(MultimapDeserializer origin, KeyDeserializer keyDeserializer) {
+        super(origin.mapType, origin.keyComparator, keyDeserializer, origin.valueDeserializer);
+        containerDeserializer = origin.containerDeserializer;
+    }
+
+    @Override
+    MultimapDeserializer createDeserializer(KeyDeserializer keyDeserializer) {
+        return new MultimapDeserializer(this, keyDeserializer);
+    }
+
     @Override
     public void resolve(DeserializationContext ctxt) throws JsonMappingException {
         super.resolve(ctxt);

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/VavrDeserializers.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/VavrDeserializers.java
@@ -185,10 +185,10 @@ public class VavrDeserializers extends Deserializers.Base {
     {
         Class<?> raw = type.getRawClass();
         if (Map.class.isAssignableFrom(raw)) {
-            return new MapDeserializer(type, keyDeserializer);
+            return new MapDeserializer(type, keyDeserializer, elementDeserializer);
         }
         if (Multimap.class.isAssignableFrom(raw)) {
-            return new MultimapDeserializer(type, keyDeserializer);
+            return new MultimapDeserializer(type, keyDeserializer, elementDeserializer);
         }
         return super.findMapLikeDeserializer(type, config, beanDesc, keyDeserializer, elementTypeDeserializer, elementDeserializer);
     }

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/VavrDeserializers.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/VavrDeserializers.java
@@ -185,10 +185,10 @@ public class VavrDeserializers extends Deserializers.Base {
     {
         Class<?> raw = type.getRawClass();
         if (Map.class.isAssignableFrom(raw)) {
-            return new MapDeserializer(type);
+            return new MapDeserializer(type, keyDeserializer);
         }
         if (Multimap.class.isAssignableFrom(raw)) {
-            return new MultimapDeserializer(type);
+            return new MultimapDeserializer(type, keyDeserializer);
         }
         return super.findMapLikeDeserializer(type, config, beanDesc, keyDeserializer, elementTypeDeserializer, elementDeserializer);
     }

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/VavrDeserializers.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/VavrDeserializers.java
@@ -185,10 +185,10 @@ public class VavrDeserializers extends Deserializers.Base {
     {
         Class<?> raw = type.getRawClass();
         if (Map.class.isAssignableFrom(raw)) {
-            return new MapDeserializer(type, keyDeserializer, elementDeserializer);
+            return new MapDeserializer(type, keyDeserializer, elementTypeDeserializer, elementDeserializer);
         }
         if (Multimap.class.isAssignableFrom(raw)) {
-            return new MultimapDeserializer(type, keyDeserializer, elementDeserializer);
+            return new MultimapDeserializer(type, keyDeserializer, elementTypeDeserializer, elementDeserializer);
         }
         return super.findMapLikeDeserializer(type, config, beanDesc, keyDeserializer, elementTypeDeserializer, elementDeserializer);
     }

--- a/src/main/java/io/vavr/jackson/datatype/serialize/MapSerializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/serialize/MapSerializer.java
@@ -19,8 +19,8 @@
  */
 package io.vavr.jackson.datatype.serialize;
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.ser.ContextualSerializer;
 import com.fasterxml.jackson.databind.type.MapLikeType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.vavr.collection.Map;
@@ -28,12 +28,16 @@ import io.vavr.collection.Map;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 
-class MapSerializer extends ValueSerializer<Map<?, ?>> {
+class MapSerializer extends ValueSerializer<Map<?, ?>> implements ContextualSerializer {
 
     private static final long serialVersionUID = 1L;
 
+    MapSerializer(JavaType type, BeanProperty beanProperty) {
+        super(type, beanProperty);
+    }
+
     MapSerializer(JavaType type) {
-        super(type);
+        this(type, null);
     }
 
     @Override
@@ -50,5 +54,13 @@ class MapSerializer extends ValueSerializer<Map<?, ?>> {
     @Override
     public boolean isEmpty(SerializerProvider provider, Map<?, ?> value) {
         return value.isEmpty();
+    }
+
+    @Override
+    public JsonSerializer<?> createContextual(SerializerProvider prov, BeanProperty property) throws JsonMappingException {
+        if (property == beanProperty) {
+            return this;
+        }
+        return new MapSerializer(type, property);
     }
 }

--- a/src/test/java/io/vavr/jackson/datatype/map/MapTest.java
+++ b/src/test/java/io/vavr/jackson/datatype/map/MapTest.java
@@ -216,8 +216,14 @@ public abstract class MapTest extends BaseTest {
     void testContextualSerialization() throws IOException {
         Map<CustomKey, String> empty = emptyMap();
         Map<CustomKey, String> map = empty.put(new CustomKey(123), "test");
-        Model model = new Model(map);
-        String json = mapper().writeValueAsString(model);
+
+        Model source = new Model(map);
+        String json = mapper().writeValueAsString(source);
         assertEquals("{\"map\":{\"123\":\"test\"}}", json);
+
+        Model restored = mapper().readValue(json, Model.class);
+        assertEquals(1, restored.map.size());
+        assertEquals(123, restored.map.get()._1.id);
+        assertEquals("test", restored.map.get()._2);
     }
 }

--- a/src/test/java/io/vavr/jackson/datatype/multimap/MultimapTest.java
+++ b/src/test/java/io/vavr/jackson/datatype/multimap/MultimapTest.java
@@ -140,7 +140,7 @@ public abstract class MultimapTest extends BaseTest {
     static class CustomElementSerializer extends JsonSerializer<CustomElement> {
         @Override
         public void serialize(CustomElement value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-            jgen.writeFieldName(value.value);
+            jgen.writeString(value.value);
         }
     }
 


### PR DESCRIPTION
## Overview

Part of #157 , this PR makes the serialization and deserialization contextual for VAVR Map and Multimap. Let's see a concrete example before going further:

```java
@JsonProperty
@JsonSerialize(
    keyUsing = CustomKeySerializer.class,
    contentUsing = CustomValueSerializer.class
)
public Map<CustomKey, CustomValue> getMap() {
    return map;
}
```

Sometimes, users may want to use a custom serializer or deserializer for their key or content of their map. This is now possible thanks to contextualization. Now, let's see how this is done in Map and Multimap.

## Map Serialization

Map serialization emulates VAVR Map to Java LinkedHashMap. To support the contextualization, saving the bean property is enough.

## Multimap Serialization

Multimap serialization emulates VAVR Map to Java Map as `LinkedHashMap<K, ArrayList<V>>`. To support the contextualization, saving the bean property as done in map serialization. However, we have more bindings in the Java type than before, so using magic number to get the contained K, V via `type.containedType(...)` does not work anymore. Instead, using `mapType.getKeyType()` and `mapType.getContentType()` work.

## Map/Multimap Deserialization

For map-like deserialization, the changes are similar to previous PRs where we save 3 additional attributes to deserializer: 1) key deserializer 2) type deserializer of the element 3) JSON deserializer of the element. These 3 attributes may be changed during contextualization, since a new deserializer can be found by Jackson after the lookup. As you can see, these three attributes are now marked as `final`. Meaning that if anything is modified, we create a new deserializer by copying the information from the existing one. Since the deserializer are handled by contextualization, I removed the logic from resolution (`ResolvableDeserializer#resolve(...)`) since it's redundant.

## Additional Notes

The changes of this PR is mainly inspired by Jackson Databind 2.7, the version used by VAVR-Jackson. https://github.com/FasterXML/jackson-databind/blob/2.7/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java

Different from Map, Multimap does not support `contentUsing`, because the content of `Multimap<K, V>` is not `V` but multiple `V`s. So defining a custom serializer and deserializer via `contentUsing=` for V is not the right way to do. The workaround for custom-value-type serialization is:

```java
Multimap<CustomKey, CustomElement> map;
```

```java
    @JsonSerialize(using = CustomElementSerializer.class)
    @JsonDeserialize(using = CustomElementDeserializer.class)
    static class CustomElement {
        private final String value;

        CustomElement(String value) {
            this.value = value;
        }
    }
```
See more detail in `MultimapTest#testContextualizationOfKeyAndElement`.
