### PR TITLE
Remove JavaType as input argument of emulatedJavaType()

### DIFF
--- a/src/main/java/io/vavr/jackson/datatype/serialize/ArraySerializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/serialize/ArraySerializer.java
@@ -31,12 +31,14 @@ import java.util.ArrayList;
 class ArraySerializer<T extends Value<?>> extends ValueSerializer<T> implements ContextualSerializer {
 
     private static final long serialVersionUID = 1L;
+    private final CollectionLikeType collectionType;
 
-    ArraySerializer(JavaType collectionType, BeanProperty property) {
+    ArraySerializer(CollectionLikeType collectionType, BeanProperty property) {
         super(collectionType, property);
+        this.collectionType = collectionType;
     }
 
-    ArraySerializer(JavaType collectionType) {
+    ArraySerializer(CollectionLikeType collectionType) {
         this(collectionType, null);
     }
 
@@ -47,7 +49,7 @@ class ArraySerializer<T extends Value<?>> extends ValueSerializer<T> implements 
      * @param property the new bean property
      */
     ArraySerializer(ArraySerializer<T> origin, BeanProperty property) {
-        this(origin.type, property);
+        this(origin.collectionType, property);
     }
 
     @Override
@@ -56,9 +58,8 @@ class ArraySerializer<T extends Value<?>> extends ValueSerializer<T> implements 
     }
 
     @Override
-    JavaType emulatedJavaType(JavaType type, TypeFactory typeFactory) {
-        CollectionLikeType collectionLikeType = (CollectionLikeType) type;
-        return typeFactory.constructCollectionType(ArrayList.class, collectionLikeType.getContentType());
+    JavaType emulatedJavaType(TypeFactory typeFactory) {
+        return typeFactory.constructCollectionType(ArrayList.class, collectionType.getContentType());
     }
 
     @Override

--- a/src/main/java/io/vavr/jackson/datatype/serialize/CharSeqSerializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/serialize/CharSeqSerializer.java
@@ -40,7 +40,7 @@ class CharSeqSerializer extends ValueSerializer<CharSeq> {
     }
 
     @Override
-    JavaType emulatedJavaType(JavaType type, TypeFactory typeFactory) {
+    JavaType emulatedJavaType(TypeFactory typeFactory) {
         return typeFactory.constructType(String.class);
     }
 

--- a/src/main/java/io/vavr/jackson/datatype/serialize/MapSerializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/serialize/MapSerializer.java
@@ -31,13 +31,15 @@ import java.util.LinkedHashMap;
 class MapSerializer extends ValueSerializer<Map<?, ?>> implements ContextualSerializer {
 
     private static final long serialVersionUID = 1L;
+    private final MapLikeType mapType;
 
-    MapSerializer(JavaType type, BeanProperty beanProperty) {
-        super(type, beanProperty);
+    MapSerializer(MapLikeType mapType, BeanProperty beanProperty) {
+        super(mapType, beanProperty);
+        this.mapType = mapType;
     }
 
-    MapSerializer(JavaType type) {
-        this(type, null);
+    MapSerializer(MapLikeType mapType) {
+        this(mapType, null);
     }
 
     @Override
@@ -46,9 +48,8 @@ class MapSerializer extends ValueSerializer<Map<?, ?>> implements ContextualSeri
     }
 
     @Override
-    JavaType emulatedJavaType(JavaType type, TypeFactory typeFactory) {
-        MapLikeType mapLikeType = (MapLikeType) type;
-        return typeFactory.constructMapType(LinkedHashMap.class, mapLikeType.getKeyType(), mapLikeType.getContentType());
+    JavaType emulatedJavaType(TypeFactory typeFactory) {
+        return typeFactory.constructMapType(LinkedHashMap.class, mapType.getKeyType(), mapType.getContentType());
     }
 
     @Override
@@ -61,6 +62,6 @@ class MapSerializer extends ValueSerializer<Map<?, ?>> implements ContextualSeri
         if (property == beanProperty) {
             return this;
         }
-        return new MapSerializer(type, property);
+        return new MapSerializer(mapType, property);
     }
 }

--- a/src/main/java/io/vavr/jackson/datatype/serialize/MultimapSerializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/serialize/MultimapSerializer.java
@@ -33,13 +33,15 @@ import java.util.List;
 class MultimapSerializer extends ValueSerializer<Multimap<?, ?>> implements ContextualSerializer {
 
     private static final long serialVersionUID = 1L;
+    private final MapLikeType mapType;
 
-    MultimapSerializer(JavaType type) {
-        this(type, null);
+    MultimapSerializer(MapLikeType mapType) {
+        this(mapType, null);
     }
 
-    MultimapSerializer(JavaType type, BeanProperty beanProperty) {
-        super(type, beanProperty);
+    MultimapSerializer(MapLikeType mapType, BeanProperty beanProperty) {
+        super(mapType, beanProperty);
+        this.mapType = mapType;
     }
 
     @Override
@@ -57,8 +59,7 @@ class MultimapSerializer extends ValueSerializer<Multimap<?, ?>> implements Cont
     }
 
     @Override
-    JavaType emulatedJavaType(JavaType type, TypeFactory typeFactory) {
-        MapLikeType mapType = (MapLikeType) type;
+    JavaType emulatedJavaType(TypeFactory typeFactory) {
         JavaType containerType = typeFactory.constructCollectionType(ArrayList.class, mapType.getContentType());
         return typeFactory.constructMapType(LinkedHashMap.class, mapType.getKeyType(), containerType);
     }
@@ -73,6 +74,6 @@ class MultimapSerializer extends ValueSerializer<Multimap<?, ?>> implements Cont
         if (property == beanProperty) {
             return this;
         }
-        return new MultimapSerializer(type, property);
+        return new MultimapSerializer(mapType, property);
     }
 }

--- a/src/main/java/io/vavr/jackson/datatype/serialize/SerializableSerializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/serialize/SerializableSerializer.java
@@ -43,7 +43,7 @@ class SerializableSerializer<T> extends ValueSerializer<T> {
     }
 
     @Override
-    JavaType emulatedJavaType(JavaType type, TypeFactory typeFactory) {
+    JavaType emulatedJavaType(TypeFactory typeFactory) {
         return typeFactory.constructArrayType(byte.class);
     }
 

--- a/src/main/java/io/vavr/jackson/datatype/serialize/ValueSerializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/serialize/ValueSerializer.java
@@ -48,7 +48,7 @@ abstract class ValueSerializer<T> extends StdSerializer<T> {
     }
 
     abstract Object toJavaObj(T value) throws IOException;
-    abstract JavaType emulatedJavaType(JavaType type, TypeFactory typeFactory);
+    abstract JavaType emulatedJavaType(TypeFactory typeFactory);
 
     @Override
     public void serialize(T value, JsonGenerator gen, SerializerProvider provider) throws IOException {
@@ -58,7 +58,7 @@ abstract class ValueSerializer<T> extends StdSerializer<T> {
         } else {
             JsonSerializer<Object> ser;
             try {
-                JavaType emulated = emulatedJavaType(type, provider.getTypeFactory());
+                JavaType emulated = emulatedJavaType(provider.getTypeFactory());
                 if (emulated.getRawClass() != Object.class) {
                     ser = provider.findTypedValueSerializer(emulated, true, beanProperty);
                 } else {


### PR DESCRIPTION
The main motivation is to avoid type casting. Each serializer receives a meaningful Java type during it's construction: collection-like type, map-like type. By storing this information properly, we can avoid type casting which could be unsafe.