### PR TITLE
Refactoring: determine keyComparator at construction time

### DIFF
--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MapDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MapDeserializer.java
@@ -38,11 +38,11 @@ class MapDeserializer extends MaplikeDeserializer<Map<?, ?>> {
 
     MapDeserializer(MapLikeType mapType, KeyDeserializer keyDeserializer, TypeDeserializer elementTypeDeserializer,
                     JsonDeserializer<?> elementDeserializer) {
-        super(mapType, null, keyDeserializer, elementTypeDeserializer, elementDeserializer);
+        super(mapType, keyDeserializer, elementTypeDeserializer, elementDeserializer);
     }
 
     MapDeserializer(MapDeserializer origin, KeyDeserializer keyDeserializer, TypeDeserializer elementTypeDeserializer, JsonDeserializer<?> valueDeserializer) {
-        super(origin.mapType, origin.keyComparator, keyDeserializer, elementTypeDeserializer, valueDeserializer);
+        super(origin.mapType, keyDeserializer, elementTypeDeserializer, valueDeserializer);
     }
 
     @Override
@@ -79,4 +79,5 @@ class MapDeserializer extends MaplikeDeserializer<Map<?, ?>> {
         // default deserialization [...] -> Map
         return HashMap.ofEntries(result);
     }
+
 }

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MaplikeDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MaplikeDeserializer.java
@@ -22,7 +22,6 @@ package io.vavr.jackson.datatype.deserialize;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.deser.ContextualKeyDeserializer;
-import com.fasterxml.jackson.databind.deser.ResolvableDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.type.MapLikeType;
@@ -30,7 +29,7 @@ import com.fasterxml.jackson.databind.type.MapLikeType;
 import java.io.Serializable;
 import java.util.Comparator;
 
-abstract class MaplikeDeserializer<T> extends StdDeserializer<T> implements ResolvableDeserializer, ContextualDeserializer {
+abstract class MaplikeDeserializer<T> extends StdDeserializer<T> implements ContextualDeserializer {
 
     private static final long serialVersionUID = 1L;
 
@@ -72,10 +71,6 @@ abstract class MaplikeDeserializer<T> extends StdDeserializer<T> implements Reso
     abstract MaplikeDeserializer<T> createDeserializer(KeyDeserializer keyDeserializer,
                                                        TypeDeserializer elementTypeDeserializer,
                                                        JsonDeserializer<?> elementDeserializer);
-
-    @Override
-    public void resolve(DeserializationContext ctxt) throws JsonMappingException {
-    }
 
     @Override
     public JsonDeserializer<?> createContextual(DeserializationContext context, BeanProperty property) throws JsonMappingException {

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MultimapDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MultimapDeserializer.java
@@ -42,12 +42,12 @@ class MultimapDeserializer extends MaplikeDeserializer<Multimap<?, ?>> {
 
     MultimapDeserializer(MapLikeType mapType, KeyDeserializer keyDeserializer, TypeDeserializer elementTypeDeserializer,
                          JsonDeserializer<?> elementDeserializer) {
-        super(mapType, null, keyDeserializer, elementTypeDeserializer, elementDeserializer);
+        super(mapType, keyDeserializer, elementTypeDeserializer, elementDeserializer);
     }
 
     MultimapDeserializer(MultimapDeserializer origin, KeyDeserializer keyDeserializer,
                          TypeDeserializer elementTypeDeserializer, JsonDeserializer<?> elementDeserializer) {
-        super(origin.mapType, origin.keyComparator, keyDeserializer, elementTypeDeserializer, elementDeserializer);
+        super(origin.mapType, keyDeserializer, elementTypeDeserializer, elementDeserializer);
         containerDeserializer = origin.containerDeserializer;
     }
 

--- a/src/main/java/io/vavr/jackson/datatype/deserialize/MultimapDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/MultimapDeserializer.java
@@ -22,6 +22,7 @@ package io.vavr.jackson.datatype.deserialize;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.deser.ResolvableDeserializer;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.type.MapLikeType;
 import io.vavr.Tuple;
@@ -34,7 +35,7 @@ import io.vavr.collection.TreeMultimap;
 import java.io.IOException;
 import java.util.ArrayList;
 
-class MultimapDeserializer extends MaplikeDeserializer<Multimap<?, ?>> {
+class MultimapDeserializer extends MaplikeDeserializer<Multimap<?, ?>> implements ResolvableDeserializer {
 
     private static final long serialVersionUID = 1L;
 
@@ -59,7 +60,6 @@ class MultimapDeserializer extends MaplikeDeserializer<Multimap<?, ?>> {
 
     @Override
     public void resolve(DeserializationContext ctxt) throws JsonMappingException {
-        super.resolve(ctxt);
         JavaType containerType = ctxt.getTypeFactory().constructCollectionType(ArrayList.class, mapType.getContentType());
         containerDeserializer = ctxt.findContextualValueDeserializer(containerType, null);
     }


### PR DESCRIPTION
For map-like deserializer, determine `keyComparator` at construction time instead of resolution time (`ResolvableDeserializer#resolve`). It allows us to have a deterministic key-comparator during the entire lifecycle of a deserializer.

```diff
-    Comparator<Object> keyComparator;
+    final Comparator<Object> keyComparator;
```