### PR TITLE
stop using deprecated method that is removed in jackson 2.16

### DIFF
--- a/src/main/java/io/vavr/jackson/datatype/deserialize/CharSeqDeserializer.java
+++ b/src/main/java/io/vavr/jackson/datatype/deserialize/CharSeqDeserializer.java
@@ -48,7 +48,8 @@ class CharSeqDeserializer extends StdDeserializer<CharSeq> implements Resolvable
         if (obj instanceof String) {
             return CharSeq.of((String) obj);
         } else {
-            throw ctxt.wrongTokenException(p, JsonToken.VALUE_STRING, "CharSeq can only be deserialized from String");
+            throw ctxt.wrongTokenException(p, (JavaType) null,
+                JsonToken.VALUE_STRING, "CharSeq can only be deserialized from String");
         }
     }
 


### PR DESCRIPTION
Found when testing with Jackson 2.16. Another change in Jackson 2.16 breaks Either deserialization - it also broke the equivalent code in jackson-module-scala.