### PR TITLE
Update jackson from 2.15.2 to 2.16.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 junitJupiterVersion=5.9.1
 vavrVersion=1.0.0-SNAPSHOT
-fasterxmlVersion=2.15.2
+fasterxmlVersion=2.16.1
 javapoetVersion=1.13.0
 jaxbVersion=2.3.1
 nexusPublish=1.1.0


### PR DESCRIPTION
In order to fix high severity issue in the current jackson lib version:

https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31507?_gl=1%2a11dae2k%2a_ga%2aMTQ5NjA4Nzc4MS4xNzA3OTE1Nzg0%2a_ga_X9SH3KP7B4%2aMTcwODY3NzIzMy4yLjEuMTcwODY3ODg2OC4wLjAuMA..