### PR TITLE
Test jackson-databind versions: 2.15.4, 2.16.2, 2.17.2, 2.18.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         java: [ 8, 11, 17, 21, 23 ]
-        fasterxmlVersion: [ 2.8.11, 2.9.10, 2.10.4, 2.11.3, 2.12.3, 2.13.4, 2.14.1 ]
+        fasterxmlVersion: [ 2.8.11, 2.9.10, 2.10.4, 2.11.3, 2.12.3, 2.13.4, 2.14.1, 2.15.4, 2.16.2, 2.17.2, 2.18.0 ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Depends on: https://github.com/vavr-io/vavr-jackson/pull/221