### PR TITLE
Prepare for 0.11.0 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         java: [ 8, 11, 17, 21, 23 ]
-        fasterxmlVersion: [ 2.8.11, 2.9.10, 2.10.4, 2.11.3, 2.12.3, 2.13.4, 2.14.1, 2.15.4, 2.16.2, 2.17.2, 2.18.0 ]
+        fasterxmlVersion: [ 2.18.3 ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 junitJupiterVersion=5.11.2
-vavrVersion=0.10.5
-fasterxmlVersion=2.7.2
+vavrVersion=0.10.6
+fasterxmlVersion=2.18.3
 javapoetVersion=1.9.0
 jaxbVersion=2.3.0


### PR DESCRIPTION
When bumping a minor version up, we can bump minor versions up of our dependencies - in this case, we can finally use the newest possible Jackson

related: https://github.com/vavr-io/vavr-jackson/issues/199